### PR TITLE
Add stylelint 16 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "version-changelog": "^3.1.1"
   },
   "peerDependencies": {
-    "stylelint": "^14.0.0 || ^15.0.0"
+    "stylelint": "^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "engines": {
     "node": ">=12 || >=16"


### PR DESCRIPTION
The plugin seems to work with stylelint 16, so should be added as peer dependency.